### PR TITLE
Add tests

### DIFF
--- a/Die.swift
+++ b/Die.swift
@@ -5,28 +5,19 @@
 //  Copyright © 2016 Silvan Dähn. All rights reserved.
 //
 
-import Foundation
-
 let newline = "\n"
 
 /// Prints the current callstack symbols before calling exit(EXIT_FAILURE)
 /// - parameter message: The error message to print as failure reason
 @noreturn public func die(@autoclosure message: () -> String) {
-    print(message(), newline)
+    internalPrint(message(), newline)
     die()
 }
 
 /// Prints the current callstack symbols before calling exit(EXIT_FAILURE)
 @noreturn public func die() {
-    print(NSThread.callStackSymbols().joinWithSeparator(newline))
-    exit(EXIT_FAILURE)
-}
-
-/// Convenience method to execute throwing functions and die on throw
-/// - parameter message: The error message to print as failure reason
-/// - parameter block: The block to execute in which a throw will cause a die()
-public func dieOnThrow(@autoclosure message: () -> String, @noescape block: () throws -> Void) {
-    dieOnThrow(message, block: block)
+    internalPrint(NSThread.callStackSymbols().joinWithSeparator(newline))
+    internalExit(EXIT_FAILURE)
 }
 
 /// Convenience method to execute throwing functions and die on throw
@@ -43,12 +34,6 @@ public func dieOnThrow<T>(@autoclosure message: () -> String, @noescape block: (
 
 /// Convenience method to execute throwing functions and die on throw
 /// - parameter block: The block to execute in which a throw will cause a die()
-public func dieOnThrow(@noescape block: () throws -> Void) {
-    dieOnThrow(block)
-}
-
-/// Convenience method to execute throwing functions and die on throw
-/// - parameter block: The block to execute in which a throw will cause a die()
 /// - returns: The return value of the block is forwarded
 public func dieOnThrow<T>(@noescape block: () throws -> T) -> T {
     do {
@@ -56,4 +41,15 @@ public func dieOnThrow<T>(@noescape block: () throws -> T) -> T {
     } catch {
         die()
     }
+}
+
+
+// MARK: - Testing
+
+// The following varaiables provide a way to inject different behaviours for testing
+var internalExit = exit
+var internalPrint = _internalPrint
+
+func _internalPrint(items: Any...) {
+    print(items)
 }

--- a/Die.xcodeproj/project.pbxproj
+++ b/Die.xcodeproj/project.pbxproj
@@ -7,11 +7,27 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		AFA1DA031C90B4F600C65B90 /* Die.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF0D678C1C8DCD25007CE00F /* Die.framework */; };
+		AFA1DA0B1C90B50700C65B90 /* DieTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFA1DA091C90B50700C65B90 /* DieTests.swift */; };
+		AFA1DA0C1C90B50700C65B90 /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = AFA1DA0A1C90B50700C65B90 /* Info.plist */; };
 		BF0D67901C8DCD25007CE00F /* Die.h in Headers */ = {isa = PBXBuildFile; fileRef = BF0D678F1C8DCD25007CE00F /* Die.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF0D67981C8DCD2B007CE00F /* Die.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0D67971C8DCD2B007CE00F /* Die.swift */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		AFA1DA041C90B4F600C65B90 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BF0D67831C8DCD25007CE00F /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = BF0D678B1C8DCD25007CE00F;
+			remoteInfo = Die;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
+		AFA1D9FE1C90B4F600C65B90 /* DieTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DieTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		AFA1DA091C90B50700C65B90 /* DieTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DieTests.swift; sourceTree = "<group>"; };
+		AFA1DA0A1C90B50700C65B90 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		BF0D678C1C8DCD25007CE00F /* Die.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Die.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BF0D678F1C8DCD25007CE00F /* Die.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Die.h; sourceTree = "<group>"; };
 		BF0D67911C8DCD25007CE00F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -19,6 +35,14 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		AFA1D9FB1C90B4F600C65B90 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AFA1DA031C90B4F600C65B90 /* Die.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		BF0D67881C8DCD25007CE00F /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -29,10 +53,20 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		AFA1D9FF1C90B4F600C65B90 /* DieTests */ = {
+			isa = PBXGroup;
+			children = (
+				AFA1DA091C90B50700C65B90 /* DieTests.swift */,
+				AFA1DA0A1C90B50700C65B90 /* Info.plist */,
+			);
+			path = DieTests;
+			sourceTree = "<group>";
+		};
 		BF0D67821C8DCD25007CE00F = {
 			isa = PBXGroup;
 			children = (
 				BF0D678E1C8DCD25007CE00F /* Die */,
+				AFA1D9FF1C90B4F600C65B90 /* DieTests */,
 				BF0D678D1C8DCD25007CE00F /* Products */,
 			);
 			sourceTree = "<group>";
@@ -41,6 +75,7 @@
 			isa = PBXGroup;
 			children = (
 				BF0D678C1C8DCD25007CE00F /* Die.framework */,
+				AFA1D9FE1C90B4F600C65B90 /* DieTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -69,6 +104,24 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		AFA1D9FD1C90B4F600C65B90 /* DieTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = AFA1DA081C90B4F600C65B90 /* Build configuration list for PBXNativeTarget "DieTests" */;
+			buildPhases = (
+				AFA1D9FA1C90B4F600C65B90 /* Sources */,
+				AFA1D9FB1C90B4F600C65B90 /* Frameworks */,
+				AFA1D9FC1C90B4F600C65B90 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				AFA1DA051C90B4F600C65B90 /* PBXTargetDependency */,
+			);
+			name = DieTests;
+			productName = DieTests;
+			productReference = AFA1D9FE1C90B4F600C65B90 /* DieTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		BF0D678B1C8DCD25007CE00F /* Die */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = BF0D67941C8DCD25007CE00F /* Build configuration list for PBXNativeTarget "Die" */;
@@ -93,9 +146,13 @@
 		BF0D67831C8DCD25007CE00F /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftUpdateCheck = 0720;
 				LastUpgradeCheck = 0720;
 				ORGANIZATIONNAME = "Silvan Dähn";
 				TargetAttributes = {
+					AFA1D9FD1C90B4F600C65B90 = {
+						CreatedOnToolsVersion = 7.2.1;
+					};
 					BF0D678B1C8DCD25007CE00F = {
 						CreatedOnToolsVersion = 7.2.1;
 					};
@@ -114,11 +171,20 @@
 			projectRoot = "";
 			targets = (
 				BF0D678B1C8DCD25007CE00F /* Die */,
+				AFA1D9FD1C90B4F600C65B90 /* DieTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		AFA1D9FC1C90B4F600C65B90 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AFA1DA0C1C90B50700C65B90 /* Info.plist in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		BF0D678A1C8DCD25007CE00F /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -129,6 +195,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		AFA1D9FA1C90B4F600C65B90 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AFA1DA0B1C90B50700C65B90 /* DieTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		BF0D67871C8DCD25007CE00F /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -139,7 +213,40 @@
 		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXTargetDependency section */
+		AFA1DA051C90B4F600C65B90 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = BF0D678B1C8DCD25007CE00F /* Die */;
+			targetProxy = AFA1DA041C90B4F600C65B90 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
 /* Begin XCBuildConfiguration section */
+		AFA1DA061C90B4F600C65B90 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				INFOPLIST_FILE = DieTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = de.silvandaehn.DieTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		AFA1DA071C90B4F600C65B90 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				INFOPLIST_FILE = DieTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = de.silvandaehn.DieTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
 		BF0D67921C8DCD25007CE00F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -268,6 +375,14 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		AFA1DA081C90B4F600C65B90 /* Build configuration list for PBXNativeTarget "DieTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AFA1DA061C90B4F600C65B90 /* Debug */,
+				AFA1DA071C90B4F600C65B90 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
 		BF0D67861C8DCD25007CE00F /* Build configuration list for PBXProject "Die" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -284,6 +399,7 @@
 				BF0D67961C8DCD25007CE00F /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/Die.xcodeproj/xcshareddata/xcschemes/DieTests.xcscheme
+++ b/Die.xcodeproj/xcshareddata/xcschemes/DieTests.xcscheme
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0720"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AFA1D9FD1C90B4F600C65B90"
+               BuildableName = "DieTests.xctest"
+               BlueprintName = "DieTests"
+               ReferencedContainer = "container:Die.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/DieTests/DieTests.swift
+++ b/DieTests/DieTests.swift
@@ -1,0 +1,139 @@
+//
+//  DieTests.swift
+//  DieTests
+//
+//  Created by Silvan Dähn on 09.03.16.
+//  Copyright © 2016 Silvan Dähn. All rights reserved.
+//
+
+import XCTest
+@testable import Die
+
+extension String: ErrorType {}
+
+class DieTests: XCTestCase {
+
+    var callCount = 0
+    var exitStatus: Int32?
+    var printHistory: [[Any]] = []
+    let spinMainQueue = NSThread.sleepForTimeInterval
+
+    // MARK: - Mocking
+
+    @noreturn private func mockExit(status: Int32) {
+        exitStatus = status
+        callCount++
+        repeat { NSRunLoop.currentRunLoop().run() } while (true)
+    }
+
+    func mockPrint(items: Any...) {
+        printHistory.append(items)
+    }
+
+    // MARK: - Setup
+
+    override func setUp() {
+        super.setUp()
+        (callCount, exitStatus, printHistory) = (0, nil, [])
+        (internalExit, internalPrint)  = (mockExit, mockPrint)
+    }
+    
+    override func tearDown() {
+        (internalExit, internalPrint) = (exit, _internalPrint)
+        super.tearDown()
+    }
+
+    // MARK: - Tests
+
+    func testThatItCallsDie() {
+        // when
+        dispatch(die)
+        spinMainQueue(1)
+
+        // then
+        XCTAssertEqual(callCount, 1)
+        XCTAssertEqual(exitStatus, EXIT_FAILURE)
+    }
+
+    func testThatItCallsExitAndPrintsTheMessageAndNewline() {
+        // given
+        let message = "🚫"
+
+        // when
+        dispatch { die(message) }
+        spinMainQueue(1)
+
+        // then
+        XCTAssertEqual(callCount, 1)
+        XCTAssertEqual(printHistory.count, 2)
+        assertMessagePrinted(message, printHistory)
+    }
+
+    func testThatItCallsDieOnThrow() {
+        // when
+        dispatch {
+            dieOnThrow {
+                throw "Error"
+            }
+        }
+
+        spinMainQueue(1)
+
+        // then
+        XCTAssertEqual(callCount, 1)
+        XCTAssertEqual(exitStatus, EXIT_FAILURE)
+    }
+
+    func testThatItCallsDieAndPrintsTheMessageOnThrow() {
+        // given
+        let message = "🚫"
+
+        // when
+        dispatch {
+            dieOnThrow(message) {
+                throw "Error"
+            }
+        }
+
+        spinMainQueue(1)
+
+        // then
+        XCTAssertEqual(callCount, 1)
+        XCTAssertEqual(exitStatus, EXIT_FAILURE)
+        XCTAssertEqual(printHistory.count, 2)
+        assertMessagePrinted(message, printHistory)
+    }
+
+    func testThatItDoesNotCallDieIfItDoesNotThrow() {
+        // given
+        var solution: Int?
+
+        // when
+        dispatch {
+            solution = dieOnThrow {
+                return 42
+            }
+        }
+
+        spinMainQueue(1)
+
+        // then
+        XCTAssertEqual(callCount, 0)
+        XCTAssertNil(exitStatus)
+        XCTAssertEqual(solution, 42)
+    }
+
+    // MARK: - Helper
+
+    func assertMessagePrinted(message: String, _ history: [[Any]]) {
+        guard let print = history.first else { return XCTFail() }
+        XCTAssertEqual(print.count, 2)
+        XCTAssertEqual(print.first as? String, message)
+        XCTAssertEqual(print.last as? String, "\n")
+    }
+
+    func dispatch(block: dispatch_block_t) {
+        let queue = dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0)
+        dispatch_async(queue, block)
+    }
+}

--- a/DieTests/DieTests.swift
+++ b/DieTests/DieTests.swift
@@ -42,6 +42,7 @@ class DieTests: XCTestCase {
     
     override func tearDown() {
         (internalExit, internalPrint) = (exit, _internalPrint)
+        expectation = nil
         super.tearDown()
     }
 
@@ -105,12 +106,12 @@ class DieTests: XCTestCase {
         var solution: Int?
 
         // when
-        self.dispatch {
+        dispatchAndWaitForDie(timeout: 2) {
             solution = dieOnThrow {
+                self.expectation?.fulfill()
                 return 42
             }
         }
-        spinMainQueue(2)
 
         // then
         XCTAssertEqual(callCount, 0)

--- a/DieTests/Info.plist
+++ b/DieTests/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>


### PR DESCRIPTION
- The `die` function now uses internal  `internalExit` and `internalPrint` functions that can be replaced in tests, in order to not call `EXIT_FAILURE` and to verify calls to `exit` or `print`
