### PR TITLE
Print arguments to `internalPrint` as space-separated string

### DIFF
--- a/Die.swift
+++ b/Die.swift
@@ -60,5 +60,6 @@ var internalExit = exit
 var internalPrint = _internalPrint
 
 func _internalPrint(items: Any...) {
-    print(items.joinWithSeparator(" "))
+    let output = items.map { "\($0)" }.joinWithSeparator(" ")
+    print(output)
 }

--- a/Die.swift
+++ b/Die.swift
@@ -60,5 +60,5 @@ var internalExit = exit
 var internalPrint = _internalPrint
 
 func _internalPrint(items: Any...) {
-    print(items)
+    print(items.joinWithSeparator(" "))
 }


### PR DESCRIPTION
Previously, they were being printed as array, such as:

```
die("a","b") 
// outputs:
// ["a","b", <callstack>]
```

now they are printed as a string

```
die("a","b") 
// outputs: 
// a b
// <callstack>
```
